### PR TITLE
Filedetection

### DIFF
--- a/ftdetect/frr.vim
+++ b/ftdetect/frr.vim
@@ -11,6 +11,7 @@ autocmd BufNewFile,BufRead bgpd_vrf*conf setfiletype frr
 autocmd BufNewFile,BufRead bgpd_vrf_prefix*conf setfiletype frr
 autocmd BufNewFile,BufRead eigrpd*conf setfiletype frr
 autocmd BufNewFile,BufRead evpn*conf setfiletype frr
+autocmd BufNewFile,BufRead frr*conf setfiletype frr
 autocmd BufNewFile,BufRead isisd*conf setfiletype frr
 autocmd BufNewFile,BufRead ldpd*conf setfiletype frr
 autocmd BufNewFile,BufRead ldp*conf setfiletype frr


### PR DESCRIPTION
Hi, 

To use your plugin I had to:
- add frr.conf filedetection
- replace the 
```vim
setfiletype frr
```
by
```vim
set filetype=frr
```
otherwise the filetype is already set as dosini and not overridden. 